### PR TITLE
refactor(#16) : 공룡 점프 높이 조절, 씬 내부에서 _elapsedTime 사용하지 않도록 변경

### DIFF
--- a/Game/Object/Player/Dinosour.cs
+++ b/Game/Object/Player/Dinosour.cs
@@ -7,10 +7,10 @@ class Dinosour : GameObject {
     private readonly float _baseYLoc;
 
     private float _ySpeed;
-    private readonly float _jumpPower = 15;
-    private readonly float _gravity = 60;
-    private readonly float _maxJumpHoldTime = 0.40f;
-    private readonly float _jumpDeadzone = 0.2f;
+    private readonly float _jumpPower;
+    private readonly float _gravity;
+    private readonly float _jumpDeadzone;
+    private readonly float _maxJumpHoldTime;
     private float _jumpHoldTime;
 
     private readonly ConsoleColor _color;
@@ -42,6 +42,11 @@ class Dinosour : GameObject {
     public override int CollisionHeight => Height - 1;
 
     public Dinosour(Scene scene) : base(scene) {
+        _jumpPower = 15;
+        _gravity = 70;
+        _jumpDeadzone = 0.2f;
+        _maxJumpHoldTime = _jumpDeadzone + 0.1f;
+
         _baseYLoc = 19 - Height;
         _runState = 0;
         _xLoc = 5;

--- a/Game/Scenes/PlayScene.cs
+++ b/Game/Scenes/PlayScene.cs
@@ -18,21 +18,18 @@ namespace Framework.MyGame
         private int _width;
         // 게임 출력 화면 높이 (해, 달 등 오브젝트 렌더링 시 사용)
         private int _height;
-        // 게임 시작 후 지난 시간
-        private float _elapsedTime;
         // 장애물 스폰 타이머
         private float _spawnTimer;
         private float _nextSpawnTime;
 
         private Random _rand = new Random();
 
-        private float _acceleration => 15f + _elapsedTime * 0.5f;
+        private float _acceleration => 30f + _score * 2;
         public event GameAction PlayAgainRequested;
         public event GameAction BackToMain;
         
         public PlayScene(int width, int height, ObstacleFactory factory) {
             _score = 0;
-            _elapsedTime = 0;
             _width = width;
             _height = height;
 
@@ -52,7 +49,6 @@ namespace Framework.MyGame
         public override void Update(float deltaTime)
         {
             if (_gameState == GameState.Playing) {
-                _elapsedTime += deltaTime;
                 _spawnTimer += deltaTime;
                 UpdateGameObjects(deltaTime, _acceleration);
             
@@ -105,7 +101,7 @@ namespace Framework.MyGame
                 // 랜덤 오브젝트 생성
                 AddGameObject(_obstacleFactory.GetRandomObstacle(_rand.Next(1, 100), this, _width, _height));
                 _spawnTimer = 0;
-                _nextSpawnTime = ( _elapsedTime * 0.1f) + 0.9f + (float)(_rand.NextDouble() * 2f);
+                _nextSpawnTime = ( _score * 0f) + 1.5f + (float)(_rand.NextDouble() * 2f);
             } else { }
         }
 


### PR DESCRIPTION
## 💭 작업 브랜치
> 브랜치를 적어주세요

refactor/#16-Balance

## 🍀 기능 설명
> 추가된 혹은 수정된 내용에 대해 간결하게 설명해주세요

공룡 점프의 데드존, 점프 높이, 중력값 조절하여 점프가 보다 게임에 적합하도록 변경

## 관련된 Issue
> 어떤 이슈를 처리했는지 작성해주세요
<!-- 처리 완료된 이슈 번호를 "close #123" 형태로 작성해주시면 Issue가 자동으로 Close 됩니다 -->
#16 